### PR TITLE
回報假衛生局網站詐騙

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -1,7 +1,7 @@
 ! FutaHosts
 ! FutaFilter Host
 ! URL: <https://github.com/FutaGuard/FutaFilter>
-! 2022.08.24.1
+! 2022.08.24.2
 ! --------------------------------------------------
 ! 白清單
 @@||ip2location.com^
@@ -129,6 +129,7 @@
 ||wsfliagov.xyz^
 ||hhigov.com^
 ||oiigov.com^
+||rvegov.com^
 
 ||taiwan-free-store.com^
 ||tw-track.com^


### PR DESCRIPTION
原網址 https://www.rvegov.com/