### PR TITLE
回報：假冒衛福部網站

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -140,6 +140,7 @@
 ||qiigov.tv^
 ||sigov.top^
 ||wsflojgov.xyz^
+||wsflbwgov.xyz^
 
 ||taiwan-free-store.com^
 ||tw-track.com^

--- a/hosts.txt
+++ b/hosts.txt
@@ -1,7 +1,7 @@
 ! FutaHosts
 ! FutaFilter Host
 ! URL: <https://github.com/FutaGuard/FutaFilter>
-! 2022.08.25.3
+! 2022.08.26.1
 ! --------------------------------------------------
 ! 白清單
 @@||ip2location.com^


### PR DESCRIPTION
原網址 http://wsflbwgov.xyz/?0wkh