### PR TITLE
監理處詐騙網址 by 新聞提供

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -223,6 +223,7 @@
 ||hjxgov.com^
 ||rinsr.vip^
 ||inloe1xf.vip^
+||mvdis-gov.vip^
 
 ||taiwan-free-store.com^
 ||tw-track.com^


### PR DESCRIPTION
https://www.ettoday.net/news/20230407/2474651.htm

民眾收到詐騙網址為｢https://mvdis-gov.vip｣的汽燃費催繳簡訊