### PR TITLE
釣魚簡訊 ipost 詐騙

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -224,6 +224,7 @@
 ||rinsr.vip^
 ||inloe1xf.vip^
 ||mvdis-gov.vip^
+||ipost-post-gov-tw.com^
 
 ||taiwan-free-store.com^
 ||tw-track.com^


### PR DESCRIPTION
原網址 https://ipost-post-gov-tw.com/