### PR TITLE
新增 中時新網域

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -228,6 +228,7 @@ newtalk.tw##div[class="ats_insert_ads"]
 www.chinatimes.com##div[class^="ad"]
 www.chinatimes.com##li[class$="yap-loaded"]
 ||www.chinatimes.com^stealth
+cpt.geniee.jp
 
 ! shoppingdesign
 shoppingdesign.com.tw#$#.IdleBox { display: none !important; }

--- a/filter.txt
+++ b/filter.txt
@@ -228,7 +228,6 @@ newtalk.tw##div[class="ats_insert_ads"]
 www.chinatimes.com##div[class^="ad"]
 www.chinatimes.com##li[class$="yap-loaded"]
 ||www.chinatimes.com^stealth
-cpt.geniee.jp
 
 ! shoppingdesign
 shoppingdesign.com.tw#$#.IdleBox { display: none !important; }

--- a/hosts.txt
+++ b/hosts.txt
@@ -213,6 +213,9 @@
 ! 低卡廣告
 ||dad-api.dcard.tw^
 
+! 中時廣告
+||cpt.geniee.jp^
+
 ! 假冒政府網站詐騙
 ||nigov.tw^
 ||oovgov.com^


### PR DESCRIPTION
中時改了不少狡詐的寫法例如動態載入、隨機ID導致舊有失效，發現廣告腳本定義來源來自這個網域，新增進去