### PR TITLE
壹蘋新聞 - 修復 Chromium 顯示元素過大 & 移除最上方動圖卡輪播

### DIFF
--- a/PureView/news.txt
+++ b/PureView/news.txt
@@ -317,7 +317,7 @@ tw.nextapple.com##aside[id="side-bar"]
 tw.nextapple.com##div[class="post-related partner"]
 tw.nextapple.com##div[class="post-comments"]
 tw.nextapple.com##div[class="tags"]
-tw.nextapple.com#$#div[id="main-content"] { width: unset !important;}
+tw.nextapple.com#$#div[id="main-content"] { width: 100% !important;}
 tw.nextapple.com##a:has-text(/推薦新聞/)
 tw.nextapple.com##a[href^="https://reporting.nextapple.com"]
 tw.nextapple.com##hr

--- a/PureView/news.txt
+++ b/PureView/news.txt
@@ -322,6 +322,8 @@ tw.nextapple.com##a:has-text(/推薦新聞/)
 tw.nextapple.com##a[href^="https://reporting.nextapple.com"]
 tw.nextapple.com##hr
 tw.nextapple.com##div[class="scrollTool"]
+tw.nextapple.com##div#top-slider
+tw.nextapple.com##div#marquee
 
 # 花蓮最速報
 hsnews.com.tw##div[id="sp-left"]

--- a/PureView/news_mobile.txt
+++ b/PureView/news_mobile.txt
@@ -237,6 +237,9 @@ tw.nextapple.com##a:has-text(/推薦新聞/)
 tw.nextapple.com##a[href^="https://reporting.nextapple.com"]
 tw.nextapple.com##hr
 tw.nextapple.com##div[class="scrollTool"]
+tw.nextapple.com##div#top-slider
+tw.nextapple.com##div#marquee
+
 # 遠見雜誌
 gvm.com.tw##section[class^="newsletter"]
 gvm.com.tw##div[class^="article-head_marketing"]

--- a/PureView/news_mobile.txt
+++ b/PureView/news_mobile.txt
@@ -232,7 +232,7 @@ tw.nextapple.com##aside[id="side-bar"]
 tw.nextapple.com##div[class="post-related partner"]
 tw.nextapple.com##div[class="post-comments"]
 tw.nextapple.com##div[class="tags"]
-tw.nextapple.com#$#div[id="main-content"] { width: unset !important;}
+tw.nextapple.com#$#div[id="main-content"] { width: 100% !important;}
 tw.nextapple.com##a:has-text(/推薦新聞/)
 tw.nextapple.com##a[href^="https://reporting.nextapple.com"]
 tw.nextapple.com##hr


### PR DESCRIPTION
- fixes #129 

- 移除最上方圖卡輪播

![tw.nextapple.com](https://github.com/user-attachments/assets/51fb62d0-ca6e-4e8b-9338-9023d1dece77)
